### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyserial
+smbus
+pillow


### PR DESCRIPTION
There is no documentation of what the required modules are to get the code to run. This PR adds a `requirements.txt` file that can be used in the normal Python way:
```sh
python3 -m pip install -r requirements.txt
```
Possibly some changes to the `README.md` explaining how to install these would be nice, but this is a simple start.

(Note that it probably makes sense to actually pin the versions of the libraries, but in that case you'd really want to set up Dependabot to keep them updated...)